### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: cpp
 
-sudo: required
-dist: trusty
-
 addons:
   apt:
     sources:


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"

Also, do not hard-code __Trusty__ because it has reached end-of-support.
https://wiki.ubuntu.com/Releases