### PR TITLE
Added -s flag to apply and save the diff.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,9 @@ It's possible to exclude paths from the recursive search::
       --exclude '*_test.cpp' \
       src include foo.cpp
 
+You can apply and save the diff to all processed files using the -s flag::
+
+  ./run-clang-format.py -r -s src include foo.cpp
 
 Continuous integration
 ======================


### PR DESCRIPTION
Thanks for this handy wrapper around clang-format!

We use it for our CI pipeline but also in our local dev environments.
Using it locally allows developers to ensure the codebase conforms to the style guide before committing. 

In this PR I've added an `-s` flag to the script, aka `--save-changes`. This flag will apply and save the diff to the files being processed. 

The existing behaviour was 
1. Print out the diff
2. Return `ExitStatus.DIFF`, 

With the addition of the `-s` flag, the behaviour is:
1. Apply and save the diff
2. Print out each file being fixed 
3. Return `ExitStatus.SUCCESS`

It can be used like this:

`./run-clang-format.py -r -s src include foo.cpp`

It is quite difficult to bulk apply suggested changes when using `clang-format`, especially recursively and cross platform. The `-s` flag solves this problem. See more info on the issue [here](https://stackoverflow.com/questions/28896909/how-to-call-clang-format-over-a-cpp-project-folder).

Thanks!


