### PR TITLE
Add clang-format-ignore file support

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -43,7 +43,7 @@ def get_clang_format_ignore_excludes(clang_format_file):
     excludes = []
     try:
         with io.open(clang_format_file, 'r', encoding='utf-8') as clang_ignore:
-            for pattern in clang_ignore.readlines():
+            for pattern in clang_ignore:
                 pattern = pattern.rstrip()
                 if not pattern or pattern.startswith('#'):
                     continue  # empty or comment

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -38,6 +38,18 @@ class ExitStatus:
     DIFF = 1
     TROUBLE = 2
 
+def get_clang_format_ignore_excludes(clang_format_file):
+    excludes = []
+    try:
+        with open(clang_format_file, 'r') as clang_ignore:
+            for pattern in clang_ignore.readlines():
+                pattern = pattern.rstrip()
+                if not pattern or pattern.startswith('#'):
+                    continue  # empty or comment
+                excludes.append(pattern)
+    except:
+        pass
+    return excludes;
 
 def list_files(files, recursive=False, extensions=None, exclude=None):
     if extensions is None:
@@ -258,6 +270,10 @@ def main():
         default=[],
         help='exclude paths matching the given glob-like pattern(s)'
         ' from recursive search')
+    parser.add_argument(
+        '--clang-format-ignore',
+        help='path to the .clang-format-ignore',
+        default='.clang-format-ignore')
 
     args = parser.parse_args()
 
@@ -298,10 +314,14 @@ def main():
         return ExitStatus.TROUBLE
 
     retcode = ExitStatus.SUCCESS
+
+    excludes = get_clang_format_ignore_excludes(args.clang_format_ignore)
+    excludes.extend(args.exclude)
+
     files = list_files(
         args.files,
         recursive=args.recursive,
-        exclude=args.exclude,
+        exclude=excludes,
         extensions=args.extensions.split(','))
 
     if not files:

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -42,7 +42,7 @@ class ExitStatus:
 def get_clang_format_ignore_excludes(clang_format_file):
     excludes = []
     try:
-        with open(clang_format_file, 'r') as clang_ignore:
+        with io.open(clang_format_file, 'r', encoding='utf-8') as clang_ignore:
             for pattern in clang_ignore.readlines():
                 pattern = pattern.rstrip()
                 if not pattern or pattern.startswith('#'):

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -31,6 +31,7 @@ except ImportError:
 
 
 DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+DEFAULT_CLANG_FORMAT_IGNORE= '.clang-format-ignore'
 
 
 class ExitStatus:
@@ -270,10 +271,6 @@ def main():
         default=[],
         help='exclude paths matching the given glob-like pattern(s)'
         ' from recursive search')
-    parser.add_argument(
-        '--clang-format-ignore',
-        help='path to the .clang-format-ignore',
-        default='.clang-format-ignore')
 
     args = parser.parse_args()
 
@@ -315,7 +312,7 @@ def main():
 
     retcode = ExitStatus.SUCCESS
 
-    excludes = get_clang_format_ignore_excludes(args.clang_format_ignore)
+    excludes = get_clang_format_ignore_excludes(DEFAULT_CLANG_FORMAT_IGNORE)
     excludes.extend(args.exclude)
 
     files = list_files(


### PR DESCRIPTION
This PR adds an option to exclude files based on patterns defined in a .clang-format-ignore file.

It works the same as passing multiple --exclude file arguments.

Fixes #12 