### PR TITLE
Error out if no files given

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -329,7 +329,8 @@ def main():
         extensions=args.extensions.split(','))
 
     if not files:
-        return
+        print_trouble(parser.prog, 'No files found', use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
 
     njobs = args.j
     if njobs == 0:


### PR DESCRIPTION
It is usually an error to run this with no matching files, so print a message and exit with an error code