### PR TITLE
Support --style=file:<path/to/file> for older versions of clang-format

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -130,7 +130,7 @@ def run_clang_format_diff(args, file):
             original = f.readlines()
     except IOError as exc:
         raise DiffError(str(exc))
-    
+
     if args.in_place:
         invocation = [args.clang_format_executable, '-i', file]
     else:
@@ -356,6 +356,21 @@ def main():
 
     if not files:
         return
+
+    if args.style:
+        # if style has pattern "file:<path/to/file>", load style from that file
+        # TODO: This is supported by clang-format itself starting with version
+        # 14, so for versions >=14 the argument should not be processed here.
+        # See https://stackoverflow.com/a/70859277
+        if args.style.startswith("file:"):
+            import yaml
+
+            style_file = args.style[5:]
+            with open(style_file, "r") as f:
+                data = yaml.safe_load(f)
+                # reformat to single line and pass as style argument
+                args.style = yaml.dump(data, default_flow_style=True)
+                args.style = args.style.replace("\n", "")
 
     njobs = args.j
     if njobs == 0:


### PR DESCRIPTION
Allows using a .clang-format file from an arbitrary location (i.e. does not need to be in the project directory or parent).

This is done by loading the file and passing the config to `clang-format` as a YAML string, i.e. like this:

    clang-format file.cpp --style "{BasedOnStyle: Google, IndentWidth: '4', ...}"

Adds conditional dependency on the `yaml` package for reading the file.

Note that starting from version 14, clang-format supports specifying a file like this on its own.  So if you are interested in merging this change, it would probably make sense to extend it a bit to check the version and only load the config like this for versions <14.