### PR TITLE
Change shebang to run with python3

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A wrapper script around clang-format, suitable for linting multiple files
 and to use for continuous integration.
 


### PR DESCRIPTION
On many distros, Python 2 is no longer installed by default and additional configuration is required to be able to run the script with the current shebang using just `python`. For instance, on Ubuntu 22.04 LTS, you would need to install `python-is-python3` or run and configure `update-alternatives` or install python 2.7.

But perhaps a more compelling argument for switching to `python3` is that the [`run-clang-tidy.py`](https://github.com/llvm/llvm-project/blob/b1aa7cd8a9f3793a04e15af813082b996519be44/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py#L1) script is also using that, so this would bring some consistency.